### PR TITLE
travis: add 1.x to go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5.3
+  - 1.x
 
 script: go test -tags noopenssl ./...
 


### PR DESCRIPTION
1.x match latest stable go version(1.9.2 today)